### PR TITLE
feat: 新增資種成員 api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 **development.env
 **.env
-backend
 backend/yarn.lock

--- a/backend/development/LOCAL_BUILD.sh
+++ b/backend/development/LOCAL_BUILD.sh
@@ -1,0 +1,4 @@
+cd ..
+export NEST_COMMAND="npm run start:dev"
+docker-compose down
+docker-compose up --build -V

--- a/backend/src/DTO/contents/members.dto.ts
+++ b/backend/src/DTO/contents/members.dto.ts
@@ -1,0 +1,31 @@
+import { 
+    IsString,
+    IsInt,
+    IsDate
+} from 'class-validator';
+
+export class MembersDTO {
+    @IsInt()
+    id: number;
+
+    @IsString()
+    name: string;
+
+    @IsString()
+    school: string;
+
+    @IsString()
+    department: string;
+
+    @IsInt()
+    grade: number;
+
+    @IsString()
+    reference: string;
+
+    @IsDate()
+    created_at: Date;
+
+    @IsDate()
+    updated_at: Date;
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserModule } from './module/users.module';
+import { ContentsModule } from './module/contents.module';
 import { AuthModule } from './module/auth.module';
 import { MailerModule } from '@nestjs-modules/mailer';
 import { EjsAdapter } from '@nestjs-modules/mailer/dist/adapters/ejs.adapter';
@@ -12,6 +13,7 @@ import configuration from './config/configuration';
     TypeOrmModule.forRoot(),
     UserModule,
     AuthModule,
+    ContentsModule,
     ConfigModule.forRoot({
       isGlobal: true,
       load: [configuration],

--- a/backend/src/controller/contents.controller.ts
+++ b/backend/src/controller/contents.controller.ts
@@ -1,0 +1,27 @@
+import {
+    Controller,
+    Get,
+    Param,
+    Post,
+    Body,
+} from '@nestjs/common';
+import { ContentsService } from '../service/contents.service';
+import { MembersDTO } from '../DTO/contents/members.dto';
+
+@Controller()
+export class ContentsController {
+    constructor(private readonly contentsService: ContentsService,) {}
+
+    @Get('members/:grade')
+    async findMembersByGrade(@Param('grade') grade: number): Promise<Object> {
+        return await this.contentsService.getMembersByGrade(grade);
+    }
+
+    @Post('member')
+    async addMember(
+        @Body() memberData: MembersDTO
+    ): Promise<Object> {
+        console.log(memberData);
+        return await this.contentsService.addMembers(memberData);
+    }
+}

--- a/backend/src/entity/members.entity.ts
+++ b/backend/src/entity/members.entity.ts
@@ -1,0 +1,42 @@
+import { Entity, PrimaryGeneratedColumn, Column } from "typeorm";
+
+@Entity('members')
+export class Members {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({
+        type: 'varchar',
+        length: 255,
+    })
+    name: string;
+
+    @Column({
+        type: 'varchar',
+        length: 255,
+    })
+    school: string;
+
+    @Column({
+        type: 'varchar',
+        length: 255,
+    })
+    department: string;
+
+    @Column()
+    grade: number;
+
+    @Column({
+        type: 'timestamp',
+        default: () => 'CURRENT_TIMESTAMP(6)'
+    })
+    created_at: Date;
+
+    @Column({
+        type: 'timestamp',
+        default: () => 'CURRENT_TIMESTAMP(6)',
+        onUpdate: 'CURRENT_TIMESTAMP(6)'
+    })
+    updated_at: Date;
+}

--- a/backend/src/module/contents.module.ts
+++ b/backend/src/module/contents.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ContentsController } from '../controller/contents.controller';
+import { ContentsService } from '../service/contents.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Members } from '../entity/members.entity';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([Members])],
+    controllers: [ContentsController],
+    providers: [ContentsService],
+})
+export class ContentsModule { }

--- a/backend/src/service/contents.service.ts
+++ b/backend/src/service/contents.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Members } from '../entity/members.entity';
+import { MembersDTO } from '../DTO/contents/members.dto';
+
+@Injectable()
+export class ContentsService {
+    constructor(
+        @InjectRepository(Members)
+        private readonly MembersRepository: Repository<Members>,
+    ) { }
+
+    async getMembersByGrade(grade:number): Promise<Object> {
+        return await this.MembersRepository.find({
+            where: {
+                grade: grade
+            }
+        })
+    }
+
+    async addMembers(memberData: MembersDTO): Promise<Object> {
+        const member = new Members();
+        member.name = memberData.name;
+        member.school = memberData.school;
+        member.department = memberData.department;
+        member.grade = memberData.grade;
+        return this.MembersRepository.save(member);
+    }
+}

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     volumes:
       - .:/usr/src/app
       - /usr/src/app/node_modules
+    env_file:
+      - .env.local
     ports:
       - "${FRONTEND_PORT:-49160}:3000"
     command: npm run dev


### PR DESCRIPTION
1. 新增 `撈取歷屆資種成員資料 api`
2. 新增 `新增資種成員資料 api`
3. table `members` 紀錄歷屆資種成員資料
4. 前端加上 `.env.local` 環境變數檔案